### PR TITLE
Keep autocomplete errors from crashing bpython

### DIFF
--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -544,10 +544,14 @@ def get_completer(completers, cursor_offset, line, **kwargs):
             double underscore methods like __len__ in method signatures
     """
 
-    for completer in completers:
-        matches = completer.matches(cursor_offset, line, **kwargs)
-        if matches is not None:
-            return sorted(matches), (completer if matches else None)
+    try:
+        for completer in completers:
+            matches = completer.matches(cursor_offset, line, **kwargs)
+            if matches is not None:
+                return sorted(matches), (completer if matches else None)
+    except:
+        pass
+
     return [], None
 
 


### PR DESCRIPTION
Perhaps a popup of some sort informing the user that an error has occurred would be better than just swallowing the error as I've done here, but I feel like a misbehaving completer should crash the application.

The completer that prompted this for me is FilenameCompletion.  I've got a test file in my directory created with `touch $'with\xFFhigh ascii'`.  If I type an open quote and a w in bpython, it crashes.  It's because 

From python, if I do:

```
>>> import glob
>>> glob.glob(u'w*') # this is what FileCompletion will end up calling
[u'without high ascii', u'with\uf0ffhigh ascii']
>>>
```

But if I do it from bpython:

```
>>> import glob
>>> glob.glob(u'w*'0
[u'without high ascii', 'with\xffhigh ascii']
>>>
```

For some reason, glob is returning one unicode and one str.  Then when get_completer calls sorted(matches), sorted throws up when it tries to decode the str from ASCII.

I don't know why glob is behaving this way or what the fix is, but I do know that it's not worth crashing bpython whenever I type `'w`.
